### PR TITLE
PAW-54 - petition ordering

### DIFF
--- a/petitions/channels_tests.py
+++ b/petitions/channels_tests.py
@@ -26,12 +26,13 @@ async def test_websocket_consumer_failures():
     connected, subprotocol = await communicator.connect()
 
     assert connected
+    response = await communicator.receive_json_from()
+    assert response is not None
 
     # Send a totally invalid command
     await communicator.send_json_to({"invalid": "invalid"})
     response = await communicator.receive_json_from()
-    assert response == {
-        "text": "Error must sent a non-empty 'command' parameter"}
+    assert response == {"text": "Error must sent a non-empty 'command' parameter"}
 
     # Send list command with no sort field
     await communicator.send_json_to({"command": "list"})
@@ -54,6 +55,8 @@ async def test_websocket_consumer_none():
     connected, subprotocol = await communicator.connect()
 
     assert connected
+    response = await communicator.receive_json_from()
+    assert response is not None
 
     await communicator.send_json_to({"command": "search"})
     assert await communicator.receive_nothing() is True
@@ -102,6 +105,8 @@ async def test_websocket_consumer_get(django_user_model):
     connected, subprotocol = await communicator.connect()
 
     assert connected
+    response = await communicator.receive_json_from()
+    assert response is not None
 
     await communicator.send_json_to({"command": "get", "id": 45})
     response = await communicator.receive_json_from()

--- a/petitions/consumers.py
+++ b/petitions/consumers.py
@@ -86,6 +86,9 @@ class PetitionConsumer(JsonWebsocketConsumer):
 
             self.send_json({"command": "get", "petition": petition})
 
+    def send_petitions(self, petitions):
+        self.send_json(serialize_petitions(petitions))
+
     def connect(self):
         """
         Endpoint for the petitions_connect route. Fires when web socket(WS) connections are made to the server.
@@ -102,7 +105,7 @@ class PetitionConsumer(JsonWebsocketConsumer):
 
         self.accept()
 
-        self.send_petitions_individually(petitions)
+        self.send_petitions(petitions)
 
     def disconnect(self, close_code):
         """
@@ -135,7 +138,7 @@ class PetitionConsumer(JsonWebsocketConsumer):
                             petitions = views.filtering_controller(
                                 petitions, data.get('filter'))
 
-                        self.send_petitions_individually(petitions)
+                        self.send_petitions(petitions)
 
                         return None
 
@@ -163,7 +166,7 @@ class PetitionConsumer(JsonWebsocketConsumer):
                     query = data.get('query', '')
                     if query:
                         petitions = views.sorting_controller("search", query)
-                        self.send_petitions_individually(petitions)
+                        self.send_petitions(petitions)
                         return None
                     return None
                 elif command == 'paginate':
@@ -177,7 +180,7 @@ class PetitionConsumer(JsonWebsocketConsumer):
                             petitions = views.filtering_controller(
                                 petitions, data.get('filter'))
                         petitions = paginate(petitions, page)
-                        self.send_petitions_individually(petitions)
+                        self.send_petitions(petitions)
                         return None
 
                     self.send_json(

--- a/petitions/consumers.py
+++ b/petitions/consumers.py
@@ -186,6 +186,5 @@ class PetitionConsumer(JsonWebsocketConsumer):
                     self.send_json(
                         {"text": "Error. Must send 'sort' parameter"})
                     return None
-            self.send_json(
-                {"text": "Error must sent a non-empty 'command' parameter"})
+            self.send_json({"text": "Error must sent a non-empty 'command' parameter"})
             return None

--- a/petitions/static/index.js
+++ b/petitions/static/index.js
@@ -23,7 +23,6 @@
                 let ordered = [],
                     cols    = 3;
 
-                console.log(this.width);
                 if (this.width <= 1035 && this.width > 815) {
                     cols = 2;
                 } else if (this.width <= 815) {

--- a/petitions/static/index.js
+++ b/petitions/static/index.js
@@ -1,4 +1,4 @@
-    window.debug = false;
+    window.debug = true;
     window.slideshow_images = {{ images|safe }};
     window.social = {{ social|safe }};
     /* Initialize the Vue.js wrappers for the page.
@@ -13,9 +13,39 @@
     var petitions = new Vue({
         el: "#petitions",
         data: {
+            width: window.innerWidth,
             loading: true,
             list: [],
             map: {}
+        },
+        computed: {
+            orderedList: function () {
+                let ordered = [],
+                    cols    = 3;
+
+                console.log(this.width);
+                if (this.width <= 1035 && this.width > 815) {
+                    cols = 2;
+                } else if (this.width <= 815) {
+                    cols = 1;
+                }
+
+                for (let col = 0; col < cols; col++) {
+                    for(let i = 0; i < this.list.length; i += cols) {
+                        let petition = this.list[i + col];
+                        if (petition !== undefined) {
+                            ordered.push(petition);
+                        }
+                    }
+                }
+
+                return ordered;
+            }
+        },
+        mounted() {
+            window.addEventListener('resize', () => {
+              this.width = window.innerWidth;
+            })
         },
         delimiters: ['{[', ']}']
     });
@@ -658,6 +688,8 @@
 
                 }
                 else {
+
+                    data = JSON.parse(data);
 
                     // Default behaviour is to update everything on response if no command is given.
                     if (data.hasOwnProperty("petitions")) {

--- a/petitions/static/index.js
+++ b/petitions/static/index.js
@@ -1,4 +1,4 @@
-    window.debug = true;
+    window.debug = false;
     window.slideshow_images = {{ images|safe }};
     window.social = {{ social|safe }};
     /* Initialize the Vue.js wrappers for the page.

--- a/petitions/templates/index.html
+++ b/petitions/templates/index.html
@@ -217,7 +217,7 @@
                 <span class="padding-top">No petitions fit that query!</span>
             </div>
             <div v-if="list.length > 0" id="petitions-container">
-                <article v-for="petition in list" v-if="!petition.deleted" v-bind:class="[petition.response ? 'responded ' : petition.in_progress ? 'in-progress ' : ''] + 'petition material-shadow material-hover transition'" :data-petition-id="petition.id">
+                <article v-for="petition in orderedList" v-if="!petition.deleted" v-bind:class="[petition.response ? 'responded ' : petition.in_progress ? 'in-progress ' : ''] + 'petition material-shadow material-hover transition'" :data-petition-id="petition.id">
                     <progress class="petition-progress" max="200" :value="petition.signatures"></progress>
                     <div class="petition-body">
                         <h4 class="petition-signatures">


### PR DESCRIPTION
[ticket](https://ritservices.atlassian.net/browse/PAW-54)

The purpose of this PR is to change how petitions are rendered on paw prints such that they read left-to-right as opposed to down-left-right. Over the course of this PR I changed how the petitions are passed to the frontend as well. It used to be that they would be serialized and sent one at a time, but that is not efficient so now I serialize all of them and then send them all at once. This should also reduce server load. 

As a result of that change to the backend, tests that were written incorrectly before began to fail. There was always supposed to be a response to the user when they first connected to the web socket, and the tests didn't account for that. Now upon connecting we look for a non-empty response before continuing. 

Additional tests are not needed for this, as nothing new has been added, and this has already been tested for.