### PR TITLE
make the "copy link" button appear as though it is clickable using CSS

### DIFF
--- a/petitions/static/index.css
+++ b/petitions/static/index.css
@@ -574,6 +574,9 @@ progress[value]::-moz-progress-bar {
 .social-icon img{
     height: 1em;
 }
+#link-copy-button > img {
+    cursor: pointer;
+}
 #petition-modal .modal-container{
     overflow-y: hidden;
 }
@@ -959,9 +962,6 @@ progress[value]::-moz-progress-bar {
     #social-share{
         margin-top: 10px;
         margin-right: calc(50% - 95px);
-    }
-    #link-copy-button > img {
-        cursor: pointer;
     }
     #header-top{
         margin: 10px;

--- a/petitions/static/index.css
+++ b/petitions/static/index.css
@@ -574,7 +574,7 @@ progress[value]::-moz-progress-bar {
 .social-icon img{
     height: 1em;
 }
-#link-copy-button > img {
+#link-copy-button {
     cursor: pointer;
 }
 #petition-modal .modal-container{

--- a/petitions/static/index.css
+++ b/petitions/static/index.css
@@ -960,6 +960,9 @@ progress[value]::-moz-progress-bar {
         margin-top: 10px;
         margin-right: calc(50% - 95px);
     }
+    #link-copy-button > img {
+        cursor: pointer;
+    }
     #header-top{
         margin: 10px;
     }


### PR DESCRIPTION
This fixes #146. the functionality already exists but was lacking the user experience.

tested in a local dev environment following the instructions in the README per below procedure:

1. copy some random text that is not a pawprints url
2. run dev server on main branch with at least one petition
3. open petition, verify hovering over link share button in bottom right corner doesn't change the cursor
4. stop dev server, check out this branch
5. start dev server
6. open petition, verify hovering over link share button in bottom right corner causes cursor to change to a pointer icon
7. open any text box, such as a new notepad window, and use ctrl-v to paste. verify that the url to the pawprint is present instead of the text copied earlier