### PR TITLE
set petition metadata if a fresh page is loaded from the server with the new url format

### DIFF
--- a/petitions/templates/index.html
+++ b/petitions/templates/index.html
@@ -4,8 +4,8 @@
 <head>
     {% load static %}
     {% load compress %}
-    <meta property="og:title" content="{{ title|title }}" />
-    <meta property="og:description" content="{{ title }}" />
+    <meta property="og:title" content="{{ petition.title }}" />
+    <meta property="og:description" content="{{ petition.description }}" />
     <meta property="og:image" content="{% static social_image %}" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />

--- a/petitions/views.py
+++ b/petitions/views.py
@@ -57,6 +57,21 @@ def index(request):
         'name': CONFIG['name'],
         'alert': alert,
     }
+    petitionid = request.GET.get('p', None)
+    if petitionid is not None:
+        petition = get_object_or_404(Petition, pk=petitionid)
+        url = "{}/?p={}".format(request.META['HTTP_HOST'], petition.id)
+        if request.is_secure():
+            url = "https://{}".format(url)
+        else:
+            url = "http://{}".format(url)
+
+        data_object['petition'] = {
+            'title': petition.title,
+            'description': petition.description,
+            'url': url,
+            'image': CONFIG['social']['image']
+        }
 
     return render(request, 'index.html', data_object)
 


### PR DESCRIPTION
I know this doesnt include every way a user can get to a page that will show a pawprints modal, but this is only intended to cover the usecase for bots as outlined in #145, so users never actually see the changes on the site itself as theyre all in the page `<head>` 


This builds on the existing functionality by making it work for the new URL format (?p=<ID>), not just the old /petitions/bots/<ID> url format.

This requires a conditional database lookup if the request URL contains the `p` query parameter when loading the index page.  


i was able to test to confirm this works on localhost using an opengraph browser extension. Discord doesn't seem to want to query for opengraph tags to localhost sites though so i cant 100% test it without hosting my dev version of pawprints on a public domain.

fixes #145 