### PR TITLE
remove CSS rules causing the header to get bigger

### DIFF
--- a/petitions/static/global.css
+++ b/petitions/static/global.css
@@ -371,11 +371,11 @@ nav .margin-right{
     display: none;
 }
 .small-header #logo{
-    height: 60px;
+    /* height: 60px; */
 }
-.small-header #logo img{
+/* .small-header #logo img{
     margin-top: 10px;
-}
+} */
 .header-scrolled{
     border-bottom: 1px solid #ccc;
     box-shadow: 0px 5px 5px -5px #ccc;


### PR DESCRIPTION
This resolves one of the issues present in #137 where the navbar gets bigger when users scroll down the page.

The resolution seemed to be to remove a couple CSS rules affecting the image top margin and the height of the images container. I do not know if this is likely to have broken anything else, but it seems unlikely to me.


CC @hannacodes Ben said you were the one mostly working on this. I'm just a random student contributor who isnt part of the team and I have no context for this issue to know whether this is the "proper" solution to the issue or not.


## Testing 
- run the site on localhost
- scroll the page
- observe the navbar stays the same size

