### PR TITLE
restore metadata title on committees page

### DIFF
--- a/petitions/templates/committees.html
+++ b/petitions/templates/committees.html
@@ -5,7 +5,7 @@
     {% load static %}
     {% include 'head.html' with analytics_id=analytics_id %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
-    <!-- <title>Committees | {{ name }}</title> -->
+    <title>Committees | {{ name }}</title>
 
     {% compress css %}
     <link rel="stylesheet" type="text/css" href="{% static '/css/about.css' %}">


### PR DESCRIPTION
this was mentioned in #137 as a small annoyance that manifests itself as the users browser tab/window showing the current URL instead of a custom name like most other pages have.

This seems to have been commented out with no explaination in the last refactor of this page