### PR TITLE
minimize the number of requests for ALL pawprints that are made to the backend

### DIFF
--- a/petitions/templates/index.html
+++ b/petitions/templates/index.html
@@ -175,7 +175,7 @@
                 <label for="search-term" class="block white-background margin-top padding cursor">
                     <div class="material-icon-container">
                         <i class="material-icons">search</i>
-                        <input id='search-term' v-model="searchString" @keyup="search" :class="(searchString ? 'searched ' : '') + 'material-input'" type="text" />
+                        <input id='search-term' v-model="searchString" @keydown.enter="search" :class="(searchString ? 'searched ' : '') + 'material-input'" type="text" />
                         <span id="search-bar-label">Search Petitions</span>
                     </div>
             <div class="search-filter">


### PR DESCRIPTION
This helps improve the performance of search.

It turns out that a request for ALL pawprints was being sent for every character the user typed in the search box. 

This might not be the only problem, but having to process that much needless extra data may affect performance

This fix changes it to only run a search when users hit enter.


This is a draft because it needs more work so as not to break existing users workflows when they expect that searched happen automatically without having to hit enter. We need a way to reliably detect when users stop typing so we can send ONE request instead of one per character. Maybe each keypress resets a 2 second timer and if the timer hits 0, THEN the request is sent?

This might be most useful in conjunction with @Sma-Das's branch to fix thesearch