### PR TITLE
Fix redis dependency and mockdata generation error (#164, #163)

### DIFF
--- a/profile/models.py
+++ b/profile/models.py
@@ -48,12 +48,12 @@ class GlobalAlert(models.Model):
 # object's save method, all saving is done with the User model.
 #
 @receiver(post_save, sender=User)
-def create_user_profile(_, instance, created, **__):
+def create_user_profile(sender, instance, created, **__):
     if created:
         Profile.objects.create(user=instance, notifications=Notifications.objects.create())
 
 
 @receiver(post_save, sender=User)
-def save_user_profile(_, instance, **__):
+def save_user_profile(sender, instance, **__):
     instance.profile.save()
     instance.profile.notifications.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ pytz==2018.7
 PyYAML==3.13
 raven==6.9.0
 rcssmin==1.0.6
-redis
+redis==3.0.1
 requests==2.21.0
 rjsmin==1.0.12
 six==1.12.0


### PR DESCRIPTION
Resolves #164, Resolves #163 

Changes
- Specify `redis` version compatible with `huey`
- Revert decorator argument `sender` causing error while generating mock data 